### PR TITLE
Set package id to nor-id-num

### DIFF
--- a/NinEngine/NinEngine.csproj
+++ b/NinEngine/NinEngine.csproj
@@ -9,5 +9,6 @@
 		<PackageId>nor-id-num</PackageId>
 		<Authors>Hans Kristian Haug</Authors>
 		<Company />
+		<PackageProjectUrl>https://github.com/hkhaug/nor-id-num</PackageProjectUrl>
 	</PropertyGroup>
 </Project>

--- a/NinEngine/NinEngine.csproj
+++ b/NinEngine/NinEngine.csproj
@@ -6,5 +6,8 @@
 		<Product>Norwegian Identity Numbers</Product>
 		<Copyright>Copyright © 2014, 2015 Hans Kristian Haug</Copyright>
 		<NeutralLanguage>en</NeutralLanguage>
+		<PackageId>nor-id-num</PackageId>
+		<Authors>Hans Kristian Haug</Authors>
+		<Company />
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The package is published as NinEngine on Nuget. Updated the project file to set package id to nor-id-num so this update is easier to find.